### PR TITLE
Adjust logging

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -2,6 +2,7 @@ akka {
   loggers = ["akka.event.slf4j.Slf4jLogger"]
   logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"
   loglevel = "DEBUG"
+  loglevel = ${?LOG_LEVEL}
   stdout-loglevel = "OFF"
   log-dead-letters = off
 }

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -9,6 +9,7 @@
     <logger name="org.apache" level="ERROR" />
     <logger name="org.apache.kafka" level="ERROR" />
     <logger name="org.apache.zookeeper" level="ERROR" />
+    <logger name="com.amazonaws" level="INFO" />
 
     <root level="debug">
         <appender-ref ref="stdout" />

--- a/src/main/scala/ExportConsumerMetricsToRegistryActor.scala
+++ b/src/main/scala/ExportConsumerMetricsToRegistryActor.scala
@@ -60,6 +60,7 @@ class BaseExportConsumerMetricsToRegistryActor(kafkaClientActorRef: ActorRef)
   }
 
   //yea the gauges aren't really meant to be used by this, but i dont want to cache the results.
+  //  o ya?  then maybe it isn't an ERROR...
   def registerOrUpdateGauge(gaugeName: String, value: Option[Long]) = {
     value match {
       case Some(v) => {
@@ -68,7 +69,7 @@ class BaseExportConsumerMetricsToRegistryActor(kafkaClientActorRef: ActorRef)
           override def getValue: Long = v
         })
       }
-      case None => log.error(s"Gauge $gaugeName has None!")
+      case None => log.debug(s"Gauge $gaugeName has None!")
     }
   }
 }


### PR DESCRIPTION
Most things were set on DEBUG, with no possibility to lower them.

Changed a gauge message that would log ERROR on a simple lack of update
for a topic to DEBUG.  Changed general logging to an env variable
(LOG_LEVEL) to allow override at runtime.  Reduced logging for
com.amazonaws, which was giving lots of logs when sending to cloudwatch.